### PR TITLE
some fixes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -136,7 +136,8 @@ define maxscale::config(
   }
 
   file {[$real_logdir,$real_datadir,$real_cachedir,$real_piddir,$real_configdir]:
-        ensure => 'directory',
+        ensure  => 'directory',
+        require => Package["${::maxscale::params::package_name}"],
   }
 
   concat::fragment{ 'GlobalSettings':

--- a/manifests/config/listener.pp
+++ b/manifests/config/listener.pp
@@ -24,7 +24,7 @@ define maxscale::config::listener (
   if $protocol == undef {
     fail('The Protocol must be set!')
   }
-  if $port == undef or !(validate_integer($port)) {
+  if $port == undef or !(is_integer($port)) {
     fail('Port must be an Integer and must be set!')
   }
 

--- a/manifests/config/server.pp
+++ b/manifests/config/server.pp
@@ -18,7 +18,7 @@ define maxscale::config::server(
   if $address == undef {
     fail('The Server address must be set to an IP oder FQDN!')
   }
-  if $port == undef or !(validate_integer($port)) {
+  if $port == undef or !(is_integer($port)) {
     fail('Port must be an Integer and must be set!')
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,53 +76,31 @@
 #
 # Philipp Frik <kotty@guns-n-girls.de>
 class maxscale (
-  $package_name = undef,
-  $repository_base_url = undef,
+  $package_name = $::maxscale::params::package_name,
+  $repository_base_url = $::maxscale::params::repository_base_url,
   $setup_mariadb_repository = true,
   $service_enable        = true,
-  $threads = undef,
-  $auth_connect_timeout = undef,
-  $auth_read_timeout = undef,
-  $auth_write_timeout = undef,
-  $ms_timestamp = undef,
-  $syslog = undef,
-  $maxlog = undef,
-  $log_to_shm = undef,
-  $log_warning = undef,
-  $log_notice = undef,
-  $log_info = undef,
-  $log_debug = undef,
-  $log_augmentation = undef,
-  $logdir = undef,
-  $datadir = undef,
-  $cachedir = undef,
-  $piddir = undef,
-  $configdir = undef,
-)  {
+  $threads = $::maxscale::params::threads,
+  $auth_connect_timeout = $::maxscale::params::auth_connect_timeout,
+  $auth_read_timeout = $::maxscale::params::auth_read_timeout,
+  $auth_write_timeout = $::maxscale::params::auth_write_timeout,
+  $ms_timestamp = $::maxscale::params::ms_timestamp,
+  $syslog = $::maxscale::params::syslog,
+  $maxlog = $::maxscale::params::maxlog,
+  $log_to_shm = $::maxscale::params::log_to_shm,
+  $log_warning = $::maxscale::params::log_warning,
+  $log_notice = $::maxscale::params::log_notice,
+  $log_info = $::maxscale::params::log_info,
+  $log_debug = $::maxscale::params::log_debug,
+  $log_augmentation = $::maxscale::params::log_augmentation,
+  $logdir = $::maxscale::params::logdir,
+  $datadir = $::maxscale::params::datadir,
+  $cachedir = $::maxscale::params::cachedir,
+  $piddir = $::maxscale::params::piddir,
+  $configdir = $::maxscale::params::configdir,
+) inherits ::maxscale::params {
 
-  include ::maxscale::params
-
-  if $package_name == undef { $package_name = $::maxscale::params::package_name }
-  if $repository_base_url == undef { $repository_base_url = $::maxscale::params::repository_base_url }
-  if $threads == undef { $threads = $::maxscale::params::threads }
-  if $auth_connect_timeout == undef { $auth_connect_timeout = $::maxscale::params::auth_connect_timeout }
-  if $auth_read_timeout == undef { $auth_read_timeout = $::maxscale::params::auth_read_timeout }
-  if $auth_write_timeout == undef { $auth_write_timeout = $::maxscale::params::auth_write_timeout }
-  if $ms_timestamp == undef { $ms_timestamp = $::maxscale::params::ms_timestamp }
-  if $syslog == undef { $syslog = $::maxscale::params::syslog }
-  if $maxlog == undef { $maxlog = $::maxscale::params::maxlog }
-  if $log_to_shm == undef { $log_to_shm = $::maxscale::params::log_to_shm }
-  if $log_warning == undef { $log_warning = $::maxscale::params::log_warning }
-  if $log_notice == undef { $log_notice = $::maxscale::params::log_notice }
-  if $log_info == undef { $log_info = $::maxscale::params::log_info }
-  if $log_debug == undef { $log_debug = $::maxscale::params::log_debug }
-  if $log_augmentation == undef { $log_augmentation = $::maxscale::params::log_augmentation }
-  if $logdir == undef { $logdir = $::maxscale::params::logdir }
-  if $datadir == undef { $datadir = $::maxscale::params::datadir }
-  if $cachedir == undef { $cachedir = $::maxscale::params::cachedir }
-  if $piddir == undef { $piddir = $::maxscale::params::piddir }
-  if $configdir == undef { $configdir = $::maxscale::params::configdir }
-
+  
   validate_bool($service_enable)
 
   ::maxscale::install { $package_name :

--- a/manifests/install/apt.pp
+++ b/manifests/install/apt.pp
@@ -45,7 +45,6 @@ define maxscale::install::apt (
         },
         repos        => 'main',
         release      => $::lsbdistcodename,
-        require      => ::Apt::Key['mariadb-maxscale']
     }
 
     package { $package_name :

--- a/manifests/install/apt.pp
+++ b/manifests/install/apt.pp
@@ -31,17 +31,18 @@ define maxscale::install::apt (
     if $repository_base_url == undef {
       $repository_base_url = $::maxscale::params::repository_base_url
     }
-    
-    ::apt::key { 'mariadb-maxscale' :
-        key        => $::maxscale::params::gpg_key_id,
-        key_server => 'keys.gnupg.net'
-    }
 
     ::apt::source { 'mariadb-maxscale' :
         architecture => 'amd64',
         location     => $repository_base_url,
-        include_src  => false,
-        include_deb  => true,
+        include      => {
+            'src' => false,
+            'deb' => true,
+        },
+        key          => {
+            'id'     => $::maxscale::params::gpg_key_id,
+            'server' => 'keys.gnupg.net'
+        },
         repos        => 'main',
         release      => $::lsbdistcodename,
         require      => ::Apt::Key['mariadb-maxscale']
@@ -51,5 +52,5 @@ define maxscale::install::apt (
         ensure  => installed,
         require => ::Apt::Source['mariadb-maxscale']
     }
-    
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class maxscale::params {
   $datadir = '/var/lib/maxscale/data/'
   $cachedir = '/var/cache/maxscale/'
   $piddir =  '/var/run/maxscale/'
-  $configdir = '/etc'
+  $configdir = '/etc/maxscale'
   $configfile = "${configdir}/maxscale.cnf"
 
   case $::lsbdistid {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,11 @@
 # == class: maxscale::para,s
 #
-# defines the default parameters for a installation 
+# defines the default parameters for a installation
 #
 class maxscale::params {
   $package_name = 'maxscale'
   $gpg_key_url = 'http://code.mariadb.com/mariadb-maxscale/MariaDB-MaxScale-GPG-KEY'
-  $gpg_key_id = '70E4618A8167EE24'
+  $gpg_key_id = '13CFDE6DD9EE9784F41AF0F670E4618A8167EE24'
   $threads = 'auto'
   $auth_connect_timeout = 3
   $auth_read_timeout = 1


### PR DESCRIPTION
these commits contain fixes to warnings and errors I got, when using the module with puppet 3.8 and 3.4 (trusty vanilla) as well as a recent version of module puppetlabs:stdlib